### PR TITLE
ISSUE-26: Create Pull Request Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/documentation_pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation_pull_request.md
@@ -1,0 +1,22 @@
+<!--
+To read our full contributing guidelines, see:
+https://github.com/esmero/archipelago-documentation/blob/8.x-1.0-beta1/docs/giveortake.md
+
+Please TITLE your Pull Request in the following format:
+ISSUE-XX: Summary of changes
+-->
+
+<!-- Enter the issue number after # (e.g. #23) for Github to automatically create a link -->
+This pull request addresses issue # .
+
+<!-- Brief (1-2 sentence) summary of the addressed issue -->
+### Issue Summary.
+
+<!-- Describe what has changed in the code and functionality -->
+### What is new?
+-
+-
+-
+
+<!-- (optional, delete if unused) -->
+### Known issues with this pull request.


### PR DESCRIPTION
This pull request addresses issue #26  .

<!-- Brief (1-2 sentence) summary of the addressed issue -->
### Issue Summary.
Issue #26 proposes to add PR and Issue templates. This pull ONLY adds the PR template, because I am using the Github UI to make these changes.

<!-- Describe what has changed in the code and functionality -->
### What is new?
- `/.github/PULL_REQUEST_TEMPLATE/documentation_pull_request.md`, containing a simple template. I am open to suggestions.

