### PR TITLE
ISSUE 29 (B): Creating a Table of Contents for WIP Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Table of Contents
 * [What is Archipelago?](https://github.com/esmero/archipelago-documentation#archipelago-commons-intro)
-* [Code of Conduct](https://github.com/esmero/archipelago-documentation/blob/8.x-1.0-beta1/CODE_OF_CONDUCT.md)
+* [Code of Conduct](https://github.com/esmero/archipelago-documentation#contributing)
 * [Instructions and Guides](https://github.com/esmero/archipelago-documentation#archipelago-deployment-quickstart)
 * [Contributing](https://github.com/esmero/archipelago-documentation#contributing)
 


### PR DESCRIPTION
# What?

See ISSUE #29 

This pull merely updates the Code of Conduct link in the Table of Contents. Before the link took you directly to the entire CoC document, now it brings you to the CoC section of the README which is consistent with the rest of the ToC functionality.