### PR TITLE
ISSUE-155: Advanced Batch Find & Replace

### DIFF
--- a/docs/find_and_replace.md
+++ b/docs/find_and_replace.md
@@ -92,8 +92,8 @@ Before executing any of the available Find and Replace Actions, the best-practic
 
 - Before the final 'Execute Action' step of your Find and Replace operation, select the option to **'☑️ only simulate and debug affected JSON'**. This will run a quick check against your Action specifications and the potentially impacted Digital Objects and Collections.
 - You can then double check that the total effected changes shown reflect your intended amount of changes. 
-   - The total number of changes will always be multipled by a factor of 2, as the Actions count a first step of checking against your data, then the second step of applying the change.
-   - If your Action specifications do not match against any JSON metadata values in your specified results, you will also see that no matches were applicable.
+    - The total number of changes will always be multipled by a factor of 2, as the Actions count a first step of checking against your data, then the second step of applying the change.
+    - If your Action specifications do not match against any JSON metadata values in your specified results, you will also see that no matches were applicable.
 
 ![Find and Replace Simulation Mode](images/find_and_replace_simulation_mode.jpg)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,8 @@ nav:
         - Linked Data Reconciliation: ami_lod_rec.md
         - Using the Islandora 7 Solr Importer: I7solrImporter.md
       - Annotations: annotations.md
-      - Find and Replace: find_and_replace.md
+      - Find and Replace:
+        - find_and_replace.md
         - Text Based Find and Replace: find_and_replace_action_text.md
         - Webform Find and Replace: find_and_replace_action_webform.md
         - JSON Patch Find and Replace: find_and_replace_action_json_patch.md


### PR DESCRIPTION
Additional cleanup to #155. `mkdocs.yml` was throwing an error locally for me, and I think that's why the `Find and Replace` heading on the site right now doesn't expand to show the subsections. Additionally there were 2 sub-bullets that were indented with 3 spaces instead of 4.