### PR TITLE
Update ci.yml, mkdocs.yml for 1.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ jobs:
         with:
           fetch-depth: 1
           repository: esmero/archipelago-deployment
-          ref: 1.3.0
+          ref: 1.4.0
           path: ./archipelago-deployment
           token:  ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
           repository: esmero/archipelago-deployment-live
-          ref: 1.3.0
+          ref: 1.4.0
           path: ./archipelago-deployment-live
           token:  ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v4

--- a/docs/search_solr_index.md
+++ b/docs/search_solr_index.md
@@ -58,6 +58,7 @@ Your metadata and data, as configured through Keyname Providers and Fields, Face
 * [Strawberry Key Name Providers, Solr Field, and Facet Configuration](strawberry_key_name_providers.md) 
 * [Advanced Search](search_advanced.md)
 * [How to Add a 'Search Within Collection' Block](search-within-collection.md)
+* For Live Archipelago Deployment Site Administrators: [Upgrading Solr](archipelago-deployment-live-search_solr_index.md)
 
 ___
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ nav:
         - Start: archipelago-deployment-live-readme.md
         - Github Workflow: archipelago-deployment-live-gitworkflow.md
         - Moving from archipelago-deployment to archipelago-deployment-live: archipelago-deployment-live-moveToLive.md
+        - Upgrading Archipelago 1.3.0 to 1.4.0 (Drupal 10.1 to 10.2.x): archipelago-deployment-live-UpgradeFrom1dot3.md
+        - Upgrading Solr: archipelago-deployment-live-search_solr_index.md
         - Upgrading Drupal 9 to Drupal 10 (1.1.0 to 1.3.0): archipelago-deployment-live-UpgradeDrupalD9toD10.md  
         - Upgrading Drupal 8 to Drupal 9 (1.0.0-RC2 to 1.0.0-RC3): archipelago-deployment-live-upgradeFromD8ToD9.md
         - Upgrading from 1.0.0-RC3 to 1.0.0: archipelago-deployment-live-upgradeFromRC3.md


### PR DESCRIPTION
- Update ci.yml to reference 1.4.0 branches
- Add more docs references from deployment-live to mkdocs.yml for @DiegoPino's guides for updating from 1.3.0 to 1.4.0 and Solr bump up 🤓 
- Add deployment-live solr update doc to the main solr index page of guides