### PR TITLE
Fix links to :strawberry: runners page.

### DIFF
--- a/docs/strawberryrunners_pager_ocr.md
+++ b/docs/strawberryrunners_pager_ocr.md
@@ -13,7 +13,7 @@ tags:
 
 The `pager` and `ocr` Post-processor operations are likely the most important pair of Strawberry Runners in your Archipelago.
 
-As stated on the [Strawberry Runners overview page](docs/strawberryrunners.md), the `pager` action uses the 'Post processor that extracts/generates Ordered Sequences of files/pages/children using Files present in an ADO' plugin. Nested one level in, the `ocr` action uses the 'Post processor that Runs OCR/HORC against files' plugin. The `ocr` operations will be executed after the completion of the `pager` operations.
+As stated on the [Strawberry Runners overview page](strawberryrunners.md), the `pager` action uses the 'Post processor that extracts/generates Ordered Sequences of files/pages/children using Files present in an ADO' plugin. Nested one level in, the `ocr` action uses the 'Post processor that Runs OCR/HORC against files' plugin. The `ocr` operations will be executed after the completion of the `pager` operations.
 
 Common changes you may wish to make for the `pager` and/or `ocr` operations include adding or removing particular types of Archipelago Digital Objects to apply these operations to.
 

--- a/docs/strawberryrunners_subtitle.md
+++ b/docs/strawberryrunners_subtitle.md
@@ -12,7 +12,7 @@ tags:
 
 # Reviewing and adjusting the `subtitle` Post-Processor operations 
 
-As stated on the [Strawberry Runners overview page](docs/strawberryrunners.md), the `subtitle` action extracts textual values from subtitle/transcript VTT files and generates time/space transmuted OCR. This transmuted OCR can be used to search within a time-based video or audio file's corresponding subtitle/transcript VTT file(s), then navigate to the matching time of the video or audio file within a media viewer.
+As stated on the [Strawberry Runners overview page](strawberryrunners.md), the `subtitle` action extracts textual values from subtitle/transcript VTT files and generates time/space transmuted OCR. This transmuted OCR can be used to search within a time-based video or audio file's corresponding subtitle/transcript VTT file(s), then navigate to the matching time of the video or audio file within a media viewer.
 
 We strongly recommend using caution when making any adjustments to the default `subtitle` configurations as this may result in unexpected issues with the transmuted OCR values in your Solr Index. Also, the `subtitle` Strawberry Runner Post-Processor needs to used with corresponding related default IIIF Server Settings Form. 
 

--- a/docs/strawberryrunners_text.md
+++ b/docs/strawberryrunners_text.md
@@ -12,7 +12,7 @@ tags:
 
 # Reviewing and adjusting the `text` Post-Processor operations 
 
-As stated on the [Strawberry Runners overview page](docs/strawberryrunners.md), the `text` action extracts textual values from Files and sends the output to the Search API.
+As stated on the [Strawberry Runners overview page](strawberryrunners.md), the `text` action extracts textual values from Files and sends the output to the Search API.
 
 # Text Settings
 

--- a/docs/strawberryrunners_wacz_binary.md
+++ b/docs/strawberryrunners_wacz_binary.md
@@ -11,7 +11,7 @@ tags:
 
 # Reviewing and adjusting the `warc_to_wacz` Post-Processor operation
 
-As stated on the [Strawberry Runners overview page](docs/strawberryrunners.md), the `warc_to_wacz` action uses the 'Post processor that uses a System Binary to process * files' operations.
+As stated on the [Strawberry Runners overview page](strawberryrunners.md), the `warc_to_wacz` action uses the 'Post processor that uses a System Binary to process * files' operations.
 
 ## Wacz Page Extractor Settings
 

--- a/docs/strawberryrunners_webpage_text.md
+++ b/docs/strawberryrunners_webpage_text.md
@@ -11,7 +11,7 @@ tags:
 
 # Reviewing and adjusting the `wacz_page_extractor` and `webpage` Post-Processor operations
 
-As stated on the [Strawberry Runners overview page](docs/strawberryrunners.md), the `wacz_page_extractor` action uses the 'Post processor that extracts/generates Indexed Page Content from WACZ files in an ADO' plugin. Nested one level in, the `webpage` action uses the 'Post processor that Indexes WACZ Frictionless data Search Index to Search API' plugin. The webpage operations will be executed after the completion of the wacz_page_extractor operations. The `ocr` operations will be executed after the completion of the `pager` operations.
+As stated on the [Strawberry Runners overview page](strawberryrunners.md), the `wacz_page_extractor` action uses the 'Post processor that extracts/generates Indexed Page Content from WACZ files in an ADO' plugin. Nested one level in, the `webpage` action uses the 'Post processor that Indexes WACZ Frictionless data Search Index to Search API' plugin. The webpage operations will be executed after the completion of the wacz_page_extractor operations. The `ocr` operations will be executed after the completion of the `pager` operations.
 
 ## Wacz Page Extractor Settings
 


### PR DESCRIPTION
# What Does This Do

While reading about pager and ocr strawberry runners, I noticed these links were broken. I made the change and tested with build and serve locally and it seems to work now.